### PR TITLE
Run save callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 coverage
 pkg
 rdoc
+*.swp


### PR DESCRIPTION
Previously, save was the only method excluded from running callbacks. That's fixed now.
