### PR TITLE
Widespread spec failure when not using memcache

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,5 +17,7 @@ class TestEntity2
   include GitModel::Persistable
 end
 
-#GitModel.logger.level = ::Logger::DEBUG
-GitModel.memcache_servers = ['localhost']
+# GitModel.logger.level = ::Logger::DEBUG
+
+# Set this to an array of memcache servers, if using memcache.
+#   GitModel.memcache_servers = ['localhost']


### PR DESCRIPTION
I've pulled down the repository and run the specs, but I get 53 failures since I'm not using memcache.

My steps:

```
cd ~/code/test
git clone https://github.com/pauldowman/gitmodel.git
rvm gemset create gitmodel-test
rvm gesmset use gitmodel-test
bundle install
rspec
```

See 53 of the 79 examples fail because of the following error:

```
Dalli::RingError:
       No server available
```

From what I can tell, the error is at [gitmodel.rb:102](https://github.com/pauldowman/gitmodel/blob/master/lib/gitmodel.rb#L102) because [spec_helper.rb:21](https://github.com/pauldowman/gitmodel/blob/master/spec/spec_helper.rb#L21) sets memcache_servers to ['localhost'].  So if I don't actually have a memcache server running, this will cause the errors in later tests.

In order to get the specs passing by default for everyone, I've commented out this line. Added another comment so people know they can use this line if they have memcache installed.
